### PR TITLE
Gave name to camera parameters

### DIFF
--- a/include/tp.h
+++ b/include/tp.h
@@ -328,14 +328,10 @@ namespace TP {
 
     struct MatrixPtr {
         uint8_t _p0[0x9C];   // 0x0000
-        float camera0;       // 0x009C
-        float camera1;       // 0x00A0
-        float camera2;       // 0x00A4
-        float camera3;       // 0x00A8
-        float camera4;       // 0x00AC
-        float camera5;       // 0x00B0
+        Vec3 target;         // 0x009C
+        Vec3 pos;            // 0x00A8
         uint8_t _p1[0x134];  // 0x00B4
-        float camera6;       // 0x01E8
+        uint16_t camera6;    // 0x01E8 // Seems related to the pitch
         uint8_t _p2[0x25C];  // 0x01EC
         float camera7;       // 0x0448
     };


### PR DESCRIPTION
I identified the first 6 camera parameters are the target position and the camera position. Also, the 7th parameter seems to be a halfword and not a float, and seems to be related to the pitch of the camera.